### PR TITLE
Fix incorrect file imports (e.g., userContext to UserContext); configure ESLint to ignore unused React imports and prop-types warnings; set unique port in Vite config

### DIFF
--- a/devadopts-project/eslint.config.js
+++ b/devadopts-project/eslint.config.js
@@ -10,7 +10,10 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        process: 'readonly',
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },
@@ -33,6 +36,9 @@ export default [
         'warn',
         { allowConstantExport: true },
       ],
+      'react/react-in-jsx-scope': 'off',
+      'no-unused-vars': ['warn', { 'varsIgnorePattern': '^React$' }],
+      'react/prop-types': 'off',
     },
   },
 ]

--- a/devadopts-project/src/App.jsx
+++ b/devadopts-project/src/App.jsx
@@ -1,7 +1,7 @@
 import './App.css'
 import { RegisterPage, NotFoundPage, LoginPage, HomePage, LandingPage, DogsDisplay, DogDetailsPage, AboutPage} from './pages';
 import { PageWrapper } from './components';
-import { UserProvider } from './contexts/userContext';
+import { UserProvider } from './contexts/UserContext';
 import { DogsProvider } from './contexts/DogsContext';
 import {Route, Routes} from 'react-router-dom';
 

--- a/devadopts-project/src/components/Login/index.jsx
+++ b/devadopts-project/src/components/Login/index.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import './Login.css';
 import {Link, useNavigate} from 'react-router-dom';
-import { userProfileContext } from '../../contexts/userContext';
+import { userProfileContext } from '../../contexts/UserContext';
 
 export default function Login() {
     const {loading, setLoading} = userProfileContext();

--- a/devadopts-project/src/components/Register/index.jsx
+++ b/devadopts-project/src/components/Register/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import './Register.css';
 import { Link, useNavigate} from 'react-router-dom';
-import { userProfileContext } from '../../contexts/userContext';
+import { userProfileContext } from '../../contexts/UserContext';
 
 export default function Register() {
     const [formData, setFormData] = useState({

--- a/devadopts-project/vite.config.js
+++ b/devadopts-project/vite.config.js
@@ -9,5 +9,8 @@ export default defineConfig({
   plugins: [react()],
   define: {
     'process.env': process.env
-  }
+  },
+  server: {
+    port: 4728
+  },
 })


### PR DESCRIPTION
Fix incorrect file imports (e.g., userContext to UserContext); configure ESLint to ignore unused React imports, prop-types, and process.env warnings; set unique port in Vite config

Please accept these changes as they make developing the code much easier to work with.